### PR TITLE
feat: sort result of UpdateTagInYamlFiles to keep output constant

### DIFF
--- a/.lighthouse/jenkins-x/lint.yaml
+++ b/.lighthouse/jenkins-x/lint.yaml
@@ -26,7 +26,7 @@ spec:
           resources:
             requests:
               cpu: 1400m
-              memory: 5Gi
+              memory: 4800Mi
           env:
           - name: GOGC
             value: "20"

--- a/.lighthouse/jenkins-x/lint.yaml
+++ b/.lighthouse/jenkins-x/lint.yaml
@@ -26,7 +26,7 @@ spec:
           resources:
             requests:
               cpu: 1400m
-              memory: 4400Mi
+              memory: 6Gi
           env:
           - name: GOGC
             value: "30"

--- a/.lighthouse/jenkins-x/lint.yaml
+++ b/.lighthouse/jenkins-x/lint.yaml
@@ -26,10 +26,10 @@ spec:
           resources:
             requests:
               cpu: 1400m
-              memory: 6Gi
+              memory: 5Gi
           env:
           - name: GOGC
-            value: "30"
+            value: "20"
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/pkg/cmd/annotate/testdata/svc/expected.yaml
+++ b/pkg/cmd/annotate/testdata/svc/expected.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: cheese
   annotations:
-    chart: cheese
     beer: 'stella'
+    chart: cheese
     wine: 'merlot'
 spec:
   ports:

--- a/pkg/cmd/annotate/testpodspec/deploy/expected.yaml
+++ b/pkg/cmd/annotate/testpodspec/deploy/expected.yaml
@@ -24,9 +24,9 @@ spec:
   template:
     metadata:
       annotations:
+        beer: 'stella'
         prometheus.io/port: "7979"
         prometheus.io/scrape: "true"
-        beer: 'stella'
         wine: 'merlot'
       labels:
         app.kubernetes.io/instance: external-dns

--- a/pkg/cmd/label/testdata/deploy/expected.yaml
+++ b/pkg/cmd/label/testdata/deploy/expected.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-dns
-    helm.sh/chart: external-dns-6.8.2
     beer: 'stella'
+    helm.sh/chart: external-dns-6.8.2
     wine: 'merlot'
   name: external-dns
   namespace: jx

--- a/pkg/cmd/label/testdata/deploy/expectednotoverride.yaml
+++ b/pkg/cmd/label/testdata/deploy/expectednotoverride.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: external-dns
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-dns
-    helm.sh/chart: external-dns-6.8.2
     beer: 'stella'
+    helm.sh/chart: external-dns-6.8.2
     wine: 'merlot'
   name: external-dns
   namespace: jx

--- a/pkg/cmd/label/testdata/svc/expected.yaml
+++ b/pkg/cmd/label/testdata/svc/expected.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: cheese
   labels:
-    wine: 'merlot'
     beer: 'stella'
+    wine: 'merlot'
 spec:
   ports:
   - port: 80

--- a/pkg/cmd/label/testdata/unsorted-labels/expected.yaml
+++ b/pkg/cmd/label/testdata/unsorted-labels/expected.yaml
@@ -3,8 +3,11 @@ kind: Service
 metadata:
   name: cheese
   labels:
+    apple: fruit
     beer: 'stella'
-    wine: reisling
+    middle: thing
+    wine: 'merlot'
+    zoo: animal
 spec:
   ports:
   - port: 80

--- a/pkg/cmd/label/testdata/unsorted-labels/expectednotoverride.yaml
+++ b/pkg/cmd/label/testdata/unsorted-labels/expectednotoverride.yaml
@@ -3,8 +3,11 @@ kind: Service
 metadata:
   name: cheese
   labels:
+    apple: fruit
     beer: 'stella'
-    wine: reisling
+    middle: thing
+    wine: 'merlot'
+    zoo: animal
 spec:
   ports:
   - port: 80

--- a/pkg/cmd/label/testdata/unsorted-labels/source.yaml
+++ b/pkg/cmd/label/testdata/unsorted-labels/source.yaml
@@ -3,8 +3,9 @@ kind: Service
 metadata:
   name: cheese
   labels:
-    beer: 'stella'
-    wine: reisling
+    zoo: animal
+    middle: thing
+    apple: fruit
 spec:
   ports:
   - port: 80

--- a/pkg/tagging/base.go
+++ b/pkg/tagging/base.go
@@ -147,7 +147,7 @@ func sortTagContent(tagNode *yaml.RNode) bool {
 	}
 
 	sort.SliceStable(pairs, byKey)
-	// write sorted pairs back into the original content slice
+	// update in-place so the yaml node reflects the new order
 	for i, pair := range pairs {
 		content[i*2] = pair.key
 		content[i*2+1] = pair.value

--- a/pkg/tagging/base.go
+++ b/pkg/tagging/base.go
@@ -132,26 +132,21 @@ func sortTagContent(tagNode *yaml.RNode) bool {
 		return false
 	}
 
-	// return early if already in order, no allocation needed
-	alreadySorted := true
-	for i := 0; i < n-1; i++ {
-		if content[i*2].Value > content[(i+1)*2].Value {
-			alreadySorted = false
-			break
-		}
-	}
-	if alreadySorted {
-		return false
-	}
-
 	// pair up keys and values before sorting so they move together
 	pairs := make([]kvPair, n)
 	for i := 0; i < n; i++ {
 		pairs[i] = kvPair{content[i*2], content[i*2+1]}
 	}
-	sort.SliceStable(pairs, func(i, j int) bool {
-		return pairs[i].key.Value < pairs[j].key.Value
-	})
+
+	// alphabetical comparison used by both the check and the sort
+	byKey := func(i, j int) bool { return pairs[i].key.Value < pairs[j].key.Value }
+
+	// return early if already in order
+	if sort.SliceIsSorted(pairs, byKey) {
+		return false
+	}
+
+	sort.SliceStable(pairs, byKey)
 	// write sorted pairs back into the original content slice
 	for i, pair := range pairs {
 		content[i*2] = pair.key

--- a/pkg/tagging/base.go
+++ b/pkg/tagging/base.go
@@ -122,13 +122,17 @@ func (o *Options) UpdateTagInYamlFiles(tagType string, tags []string) error {
 	return kyamls.ModifyFiles(o.Dir, modifyFn, o.Filter)
 }
 
+// ensures consistent label order across files to prevent spurious diffs
 func sortTagContent(tagNode *yaml.RNode) bool {
 	content := tagNode.YNode().Content
+	// each label occupies 2 slots (key + value)
 	n := len(content) / 2
+	// nothing to sort with 1 or fewer labels
 	if n < 2 {
 		return false
 	}
 
+	// return early if already in order, no allocation needed
 	alreadySorted := true
 	for i := 0; i < n-1; i++ {
 		if content[i*2].Value > content[(i+1)*2].Value {
@@ -140,6 +144,7 @@ func sortTagContent(tagNode *yaml.RNode) bool {
 		return false
 	}
 
+	// pair up keys and values before sorting so they move together
 	pairs := make([]kvPair, n)
 	for i := 0; i < n; i++ {
 		pairs[i] = kvPair{content[i*2], content[i*2+1]}
@@ -147,6 +152,7 @@ func sortTagContent(tagNode *yaml.RNode) bool {
 	sort.SliceStable(pairs, func(i, j int) bool {
 		return pairs[i].key.Value < pairs[j].key.Value
 	})
+	// write sorted pairs back into the original content slice
 	for i, pair := range pairs {
 		content[i*2] = pair.key
 		content[i*2+1] = pair.value

--- a/pkg/tagging/base.go
+++ b/pkg/tagging/base.go
@@ -40,6 +40,11 @@ type Options struct {
 	Overwrite bool
 }
 
+type kvPair struct {
+	key   *yaml.Node
+	value *yaml.Node
+}
+
 // NewCmdUpdateTag creates a command object for the command
 func NewCmdUpdateTag(tagVerb, tagType string) (*cobra.Command, *Options) {
 	o := &Options{}
@@ -107,10 +112,46 @@ func (o *Options) UpdateTagInYamlFiles(tagType string, tags []string) error {
 				modified = true
 			}
 		}
+
+		if sortTagContent(tagNode) {
+			modified = true
+		}
 		return modified, nil
 	}
 
 	return kyamls.ModifyFiles(o.Dir, modifyFn, o.Filter)
+}
+
+func sortTagContent(tagNode *yaml.RNode) bool {
+	content := tagNode.YNode().Content
+	n := len(content) / 2
+	if n < 2 {
+		return false
+	}
+
+	alreadySorted := true
+	for i := 0; i < n-1; i++ {
+		if content[i*2].Value > content[(i+1)*2].Value {
+			alreadySorted = false
+			break
+		}
+	}
+	if alreadySorted {
+		return false
+	}
+
+	pairs := make([]kvPair, n)
+	for i := 0; i < n; i++ {
+		pairs[i] = kvPair{content[i*2], content[i*2+1]}
+	}
+	sort.SliceStable(pairs, func(i, j int) bool {
+		return pairs[i].key.Value < pairs[j].key.Value
+	})
+	for i, pair := range pairs {
+		content[i*2] = pair.key
+		content[i*2+1] = pair.value
+	}
+	return true
 }
 
 func getTagNode(node *yaml.RNode, path, tagType string, o *Options) (*yaml.RNode, error) {


### PR DESCRIPTION
### Changes
Add a sort in UpdateTagInYamlFiles after labels are added to keep result order consistent

### Context
We see a lot of noise in PRs due to reordering of labels.. This is caused by the following scenarios

---
Scenario 1 — OUTPUT_DIR wiped (change outside helmfiles/)

get-selectors-and-clean.sh detects the change and runs rm -rf ${OUTPUT_DIR}/*/*/. Source-repository files are gone. jx gitops repository create writes fresh files — no pipeline label. post-build runs jx gitops label across all files, finds no existing label, calls addField which appends to the bottom.

  before wipe (label at top)
  labels:
    gitops.jenkins-x.io/pipeline: 'namespaces'
    owner: spring-financial-group
    repository: acme

  after post-build (label at bottom)
  labels:
    owner: spring-financial-group
    repository: acme
    gitops.jenkins-x.io/pipeline: 'namespaces'

---
Scenario 2 — OUTPUT_DIR not wiped (helmfiles-only change, selector run)

Source-repository files persist. jx gitops repository create runs — if spec changed, yamls.SaveFile serialises labels alphabetically, label sorts back to top. post-build finds the label, updates in-place.

  before (label at bottom from scenario 1)
  labels:
    owner: spring-financial-group
    repository: acme
    gitops.jenkins-x.io/pipeline: 'namespaces'

  after yamls.SaveFile alphabetical sort (label at top)
  labels:
    gitops.jenkins-x.io/pipeline: 'namespaces'
    owner: spring-financial-group
    repository: acme

---
Result — pipeline run flips the label across all 344 source-repository files, creating ~700 meaningless diff lines per chore: regenerated commit.
